### PR TITLE
Update action to allow a secret to be passed for private repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'The version of PHP to use.'
     required: false
     default: '8.3'
+  composer-token:
+    description: 'Token for Composer authentication.'
+    required: false
+    default: ''
   composer-version:
     description: 'The version of Composer to use.'
     required: false
@@ -50,10 +54,13 @@ runs:
         php-version: ${{ inputs.php-version }}
         tools: composer:${{ inputs.composer-version }}
         coverage: none
+      env:
+        COMPOSER_TOKEN: ${{ secrets.YOUR_TOKEN }}
 
     - id: configure-composer
+      if: inputs.composer-token != ''
       name: 'Configure Composer GitHub Token'
-      run: composer config --global --auth github-oauth.github.com ${{ github.token }}
+      run: composer config --global --auth github-oauth.github.com ${{ inputs.composer-token }}
       shell: bash
 
     - id: download-satis


### PR DESCRIPTION
Updated the action to allow a secret to be passed from the caller workflow. 

This allows private GitHub repositories outside of repository running the action to be referenced in the satis.json. 